### PR TITLE
Update sync URL in README.md to point to the correct bookmarks file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ SyncMark is a Chrome extension that allows you to sync bookmarks from a remote H
 
 The extension is currently configured to sync from:
 ```
-https://raw.githubusercontent.com/doerofeverything/bookmarks-by-doe/refs/heads/main/bookmarks_by_doe.html
+https://raw.githubusercontent.com/hansajasandeepabadalge/SyncMark/refs/heads/main/bookmarks.html
 ```
 
 To use your own bookmarks file, modify the URL in [`popup.js`](popup.js) in the [`importBookmarks`](popup.js) function.


### PR DESCRIPTION
This pull request updates the documentation to reflect a new source URL for syncing bookmarks in the Chrome extension. The README now points to a different GitHub repository for the bookmarks file.

Documentation update:

* Changed the bookmarks sync URL in `README.md` to reference `hansajasandeepabadalge/SyncMark` instead of the previous `doerofeverything/bookmarks-by-doe` repository.